### PR TITLE
WIP, feedback wanted: Reassign seats to lowest-fitness Kerbals

### DIFF
--- a/Timmers/KeepFit/KeepFitCrewMember.cs
+++ b/Timmers/KeepFit/KeepFitCrewMember.cs
@@ -114,6 +114,16 @@ namespace KeepFit
             Name = name;
         }
 
+        public bool WantsBetterSeat()
+        {
+            return true; // TODO: configurable globally / per Kerbal?
+        }
+
+        public bool WillGiveUpSeat()
+        {
+            return true; // TODO: configure globally / per Kerbal?
+        }
+
         internal void AddTime(float elapsed)
         {
             float existing = 0;


### PR DESCRIPTION
**DON'T MERGE THIS**, I'm just posting this to ask your thoughts. :)

In my Kerbal game, I run an OKS base with a science lab and an ExtraPlanetaryLaunchpads shipyard.  With the giant OKS habitat rings, I have 20 "EXERCISING" slots, and only about 11 crew.

The problem is, they're all incredibly unfit because the scientists spend most of their time in the science labs, and the engineers spend most of their time in the workshops.  I've taken to trying to move them to their jobs only when I need them and move them back afterwards, but a) it's tedious micromangement, and b) surely we can assume that they don't spend 24-7 at their posts and can put in some exercise and relaxation time each day.

What I've got here is a prototype of some seat upgrade code.  I've never touched C# before today, and my closest known language is Java (which I also haven't done in years), so this is probably extremely gross code.  Plus, it only works for loaded ships, and should really work for both loaded and unloaded.  And finally, the upgrade thing should probably be configurable.

Anyway, here's my thoughts:
- global "Kerbals can move around ship" option
  - if this isn't set, we can just skip the entire upgrade code
- per-Kerbal "wants better seat" option
  - if this is set, they'll be assigned better seats when available
  - if not set, then their current seat is the best they'll ever get
- per-Kerbal "will give up seat to less fit crewmate" option
  - if this is set, and there aren't enough comfy seats, and a crewmate is less fit than them, then they'll give up their seat
  - if not set, then their current seat is the worst they'll ever get
- if neither of the per-Kerbal options are set, then the Kerbal is locked in their current seat

The algorithm works like this:
- while iterating through the ships, we count up the number of available seats at each activity level
- while iterating through all the Kerbals in a part,
  - we track the crew at a particular activity level in `shipCrew`
  - anyone who wants an upgrade gets added to `seatUpgradePool`
- we then go through the activity levels, descending
  - `freeSeats` is initially the same as total seats at that level
  - anyone who is **not** willing to give up their seat, takes their seat (deducts 1 from `freeSeats`)
  - anyone who **is** willing to give up their seat, gets added to the `seatUpgradePool` (effectively vacating their seat immediately, but they might get it back)
  - to fill the remaining `freeSeats`, we go through the `seatUpgradePool`, from least fit to most fit

(It doesn't actually move them around the ship, it just treats them as being in a better seat than they are.  The idea is, so long as your ship isn't overcrowded, Kerbals can spend their off-duty time in a comfier environment, saving their fitness.)

If every Kerbal is set to "want upgrade" and "give up seat", then the algorithm effectively just assigns them all to the best seats in descending order — it'll maintain the same overall fitness level amongst the entire crew, because they'll all be rotated in/out based on fitness.  So as long as your station/ship isn't overcrowded, you can have people in labs, or you can have a pilot in the capsule and assume that he'll retire to the hitchhiker module when he's not actively piloting (which is most of the time, probably).

Any other settings can be used to prioritise the crew.  For example, you might have a pilot who always needs to be as healthy as possible, so you put him in an EXERCISING seat and set him to refuse to give up his seat.

I'm thinking the next steps are:
- figure out a way to adapt this code to unloaded ships
  - I'm thinking we just store the seat counts, the original activity level of each crew, and run this?
  - it should probably be split into a separate method that can operate on both loaded and unloaded using the above data only
- add some UI elements to configure this
- Connected Living Spaces mod integration
  - if CLS is installed, then treat each CLS section as a separate ship for seat upgrading purposes
  - it adds a lot of value to that mod, since now there's a real reason to design ships with highly connected spaces, beyond just "I don't have to EVA to move crew around"

Thoughts?  Is this something you'd want?
